### PR TITLE
Dynamic hubspot_owner_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,39 @@ class User extends Authenticatable{
 }
 ```
 
+#### Dynamic Contact Owner
+```
+use Datomatic\LaravelHubspotEmailNotificationChannel\HubspotEmailChannel;
+use Illuminate\Notifications\Notification;
+
+class PersonalMessage extends Notification
+{
+    ...
+
+    public function via($notifiable)
+    {
+        return ['mail', HubspotEmailChannel::class]];
+    }
+
+    public function toMail($notifiable)
+    {
+        $message = (new MailMessage)
+            ->subject(__('messages.personal_subject'))
+            ->from($this->employee->email, $this->employee->name)
+            ->metadata('hubspot_owner_id', $this->employee->hubspot_owner_id);
+
+        return $message->view(
+            'messages.personal', [
+                'title' => __('messages.personal_welcome', ['recipient' => $notifiable->name]),
+                'employee' => $this->employee
+            ]
+        );
+    }
+
+    ...
+}
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ class User extends Authenticatable{
 ```
 
 #### Dynamic Contact Owner
-```
+```php
 use Datomatic\LaravelHubspotEmailNotificationChannel\HubspotEmailChannel;
 use Illuminate\Notifications\Notification;
 

--- a/src/HubspotEmailChannel.php
+++ b/src/HubspotEmailChannel.php
@@ -55,7 +55,7 @@ class HubspotEmailChannel
         $params = [
             "properties" => [
                 "hs_timestamp" => now()->getPreciseTimestamp(3),
-                "hubspot_owner_id" => config('hubspot.hubspot_owner_id'),
+                "hubspot_owner_id" => $message->metadata['hubspot_owner_id'] ?? config('hubspot.hubspot_owner_id'),
                 "hs_email_direction" => "EMAIL",
                 "hs_email_status" => "SENT",
                 "hs_email_subject" => $message->subject,


### PR DESCRIPTION
Within our tool, we want to track emails in HubSpot from multiple senders, who are also HubSpot users. As of right now we can only have one sender which is defined within `config('hubspot.hubspot_owner_id')`.

My suggestion would be to use the metadata of the mail message to set an alternative `hubspot_owner_id` in case the sender varies. I'd be happy about your feedback or ideas!