### PR TITLE
Handle ten second rate limit

### DIFF
--- a/src/HubspotEmailChannel.php
+++ b/src/HubspotEmailChannel.php
@@ -105,7 +105,7 @@ class HubspotEmailChannel
             $params['hapikey'] = $apiKey;
         }
 
-        $http = Http::acceptJson();
+        $http = Http::acceptJson()->retry(3, 11 * 1000);
 
         if (is_null($apiKey)) {
             if (is_null(config('hubspot.access_token'))) {


### PR DESCRIPTION
In the case a lot of email messages are sent and needed to be tracked within HubSpot we receive the following error message `You have reached your ten_secondly_rolling limit.`. 

The retries should split the burst regarding the ten second rate limit.